### PR TITLE
Update SHA sum and move to defaults/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ansible-role-pyenv
 
 [![Build Status](https://travis-ci.org/azmodude/ansible-role-pyenv.svg?branch=master)](https://travis-ci.org/azmodude/ansible-role-pyenv)
 
-Install [pyenv](https://github.com/yyuu/pyenv) using [pyenv-installer](https://github.com/yyuu/pyenv-installer).
+Install [pyenv](https://github.com/pyenv/pyenv) using [pyenv-installer](https://github.com/pyenv/pyenv-installer).
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 pyenv_root: '.pyenv'
+pyenv_installer_sha256: 85ddde01331e70a135ae4204eaac58a86fdc27cdeda65da72f8868a052b7ab1d

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
       register: pyenv_filename
     - name: Download pyenv installer
       get_url:
-        url: https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer
+        url: https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer
         dest: "{{ pyenv_filename.path }}"
         mode: 0700
         sha256sum: "{{ pyenv_installer_sha256 }}"

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,2 +1,2 @@
 ---
-pyenv_installer_sha256: 9c383fc9b36330b27ed622a107bd8e9c3f52bbb48d65c5421d4f32685e6cd0c6
+# Main vars


### PR DESCRIPTION
With the current version of ansible, it is not possible to override the pyenv installer SHA checksum with a vary file or section in the playbook. By moving the checksum to defaults/main.yml, it is possible to override it - that way this role doesn't have to be updated with every release of a new pyenv master tree.